### PR TITLE
Allow deserializing string-only text component

### DIFF
--- a/.run/Run Tests.run.xml
+++ b/.run/Run Tests.run.xml
@@ -1,8 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run Tests" type="JUnit" factoryName="JUnit">
     <module name="Scroll.test" />
-    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
-    <option name="ALTERNATIVE_JRE_PATH" value="corretto-21" />
     <option name="PACKAGE_NAME" value="" />
     <option name="MAIN_CLASS_NAME" value="" />
     <option name="METHOD_NAME" value="" />

--- a/src/main/kotlin/io/github/dockyardmc/scroll/Component.kt
+++ b/src/main/kotlin/io/github/dockyardmc/scroll/Component.kt
@@ -1,12 +1,15 @@
 package io.github.dockyardmc.scroll
 
+import io.github.dockyardmc.scroll.serializers.ComponentDeserializer
 import io.github.dockyardmc.scroll.serializers.ComponentToJsonSerializer
 import io.github.dockyardmc.scroll.serializers.ComponentSerializer
+import kotlinx.serialization.KeepGeneratedSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import net.kyori.adventure.nbt.CompoundBinaryTag
 
-@Serializable
+@KeepGeneratedSerializer
+@Serializable(with = ComponentDeserializer::class)
 open class Component(
     var extra: MutableList<Component>? = null,
     var keybind: String? = null,

--- a/src/main/kotlin/io/github/dockyardmc/scroll/serializers/JsonToComponentSerializer.kt
+++ b/src/main/kotlin/io/github/dockyardmc/scroll/serializers/JsonToComponentSerializer.kt
@@ -13,7 +13,7 @@ object JsonToComponentSerializer {
     }
 }
 
-internal class ComponentDeserializer : JsonTransformingSerializer<Component>(Component.serializer()) {
+internal class ComponentDeserializer : JsonTransformingSerializer<Component>(Component.generatedSerializer()) {
     override fun transformDeserialize(element: JsonElement): JsonElement = when (element) {
         is JsonPrimitive -> buildJsonObject {
             put("text", element)

--- a/src/main/kotlin/io/github/dockyardmc/scroll/serializers/JsonToComponentSerializer.kt
+++ b/src/main/kotlin/io/github/dockyardmc/scroll/serializers/JsonToComponentSerializer.kt
@@ -2,9 +2,23 @@ package io.github.dockyardmc.scroll.serializers
 
 import io.github.dockyardmc.scroll.Component
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.JsonTransformingSerializer
+import kotlinx.serialization.json.buildJsonObject
 
 object JsonToComponentSerializer {
     fun serialize(json: String): Component {
-        return Json.decodeFromString<Component>(json)
+        return Json.decodeFromString(ComponentDeserializer(), json)
+    }
+}
+
+internal class ComponentDeserializer : JsonTransformingSerializer<Component>(Component.serializer()) {
+    override fun transformDeserialize(element: JsonElement): JsonElement = when (element) {
+        is JsonPrimitive -> buildJsonObject {
+            put("text", element)
+        }
+
+        else -> element
     }
 }

--- a/src/test/kotlin/JsonSerializationTests.kt
+++ b/src/test/kotlin/JsonSerializationTests.kt
@@ -2,6 +2,7 @@ import io.github.dockyardmc.scroll.ClickEvent
 import io.github.dockyardmc.scroll.Component
 import io.github.dockyardmc.scroll.serializers.JsonToComponentSerializer
 import io.github.dockyardmc.scroll.extensions.toComponent
+import org.junit.jupiter.api.assertDoesNotThrow
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -42,5 +43,14 @@ class JsonSerializationTests {
         val expected = """{"text":"","click_event":{"action":"show_dialog","dialog":"my_dialog"}}"""
 
         assertEquals(input.toJson(), expected)
+    }
+
+    @Test
+    fun testJsonStringToComponent() {
+        val input = "\"test_text\""
+        val expected = Component(text = "test_text")
+
+        val result = assertDoesNotThrow { JsonToComponentSerializer.serialize(input) }
+        assertEquals(expected.toJson(), result.toJson())
     }
 }


### PR DESCRIPTION
This PR fixes #1 by implementing a custom deserializer for `Component` in the form of `JsonTransformingSerializer`, which transforms string-only components with their equivalent object-form component and otherwise delegates to the plugin-generated serializer. A test is added to check the behavior.

This also adjusts the "Run Tests" run configuration slightly to remove a reference to a named JRE, so the run configuration works with the module JRE.

The second part of that issue regarding a crash for the `extras` field in JSON deserialization seems to not be applicable, perhaps due to the rewrite made in the commit immediately after the one the linked issue mentions.

---

Side-notes:
- I find it quite interesting that `Component(text = "test") == Component(text = "test")` evaluates to `false`. I'm not knowledgeable enough in Kotlin to understand why that happens though.
- You should **add a license** to this repository, as a `LICENSE` file or otherwise at the root of the repository.

(P.S. Could I please ask you to add the `hacktoberfest` topic to your repository, or label this with a `hacktoberfest-accepted` label? Thank you!)